### PR TITLE
Add nav buttons and bilingual pages

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blog | Raphael Reck</title>
+  <link rel="stylesheet" href="../style.css">
+  <script src="../script.js"></script>
+</head>
+<body>
+  <div class="container">
+    <div class="lang-switch">
+      <button onclick="toggleLanguage()">Passer en français</button>
+    </div>
+    <nav class="nav-buttons">
+      <a href="../public/services.pdf" download>Download PDF</a>
+      <a href="https://github.com/raphaelreck" target="_blank">GitHub</a>
+      <a href="https://www.linkedin.com/in/raphaelreck" target="_blank">LinkedIn</a>
+      <a href="index.html">Blog</a>
+      <a href="../roots-time/manifesto.html">Roots Time Corporation</a>
+      <a href="../memes/laugh.html">Universal Darwinism</a>
+    </nav>
+    <h1>Blog</h1>
+    <p>Posts coming weekly, usually Wednesdays.</p>
+  </div>
+</body>
+</html>

--- a/blog/index_fr.html
+++ b/blog/index_fr.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blog | Raphael Reck</title>
+  <link rel="stylesheet" href="../style.css">
+  <script src="../script.js"></script>
+</head>
+<body>
+  <div class="container">
+    <div class="lang-switch">
+      <button onclick="toggleLanguage()">English version</button>
+    </div>
+    <nav class="nav-buttons">
+      <a href="../public/services.pdf" download>Télécharger le PDF</a>
+      <a href="https://github.com/raphaelreck" target="_blank">GitHub</a>
+      <a href="https://www.linkedin.com/in/raphaelreck" target="_blank">LinkedIn</a>
+      <a href="index_fr.html">Blog</a>
+      <a href="../roots-time/manifesto_fr.html">Roots Time Corporation</a>
+      <a href="../memes/laugh_fr.html">Darwinisme universel</a>
+    </nav>
+    <h1>Blog</h1>
+    <p>Articles publiés chaque semaine, généralement le mercredi.</p>
+  </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -25,10 +25,14 @@
       </div>
     </div>
 
-    <!-- Placeholder link to the service overview PDF -->
-    <div class="pdf-download">
+    <nav class="nav-buttons">
       <a href="public/services.pdf" download>Download PDF</a>
-    </div>
+      <a href="https://github.com/raphaelreck" target="_blank">GitHub</a>
+      <a href="https://www.linkedin.com/in/raphaelreck" target="_blank">LinkedIn</a>
+      <a href="blog/index.html">Blog</a>
+      <a href="roots-time/manifesto.html">Roots Time Corporation</a>
+      <a href="memes/laugh.html">Universal Darwinism</a>
+    </nav>
 
     <div class="services">
       <section class="service">

--- a/index_fr.html
+++ b/index_fr.html
@@ -25,10 +25,14 @@
       </div>
     </div>
 
-    <!-- Lien temporaire vers le PDF de présentation des services -->
-    <div class="pdf-download">
+    <nav class="nav-buttons">
       <a href="public/services.pdf" download>Télécharger le PDF</a>
-    </div>
+      <a href="https://github.com/raphaelreck" target="_blank">GitHub</a>
+      <a href="https://www.linkedin.com/in/raphaelreck" target="_blank">LinkedIn</a>
+      <a href="blog/index_fr.html">Blog</a>
+      <a href="roots-time/manifesto_fr.html">Roots Time Corporation</a>
+      <a href="memes/laugh_fr.html">Darwinisme universel</a>
+    </nav>
 
     <div class="services">
       <section class="service">

--- a/memes/laugh.html
+++ b/memes/laugh.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Universal Darwinism | Memes</title>
+  <link rel="stylesheet" href="../style.css">
+  <script src="../script.js"></script>
+</head>
+<body>
+  <div class="container">
+    <div class="lang-switch">
+      <button onclick="toggleLanguage()">Passer en français</button>
+    </div>
+    <nav class="nav-buttons">
+      <a href="../public/services.pdf" download>Download PDF</a>
+      <a href="https://github.com/raphaelreck" target="_blank">GitHub</a>
+      <a href="https://www.linkedin.com/in/raphaelreck" target="_blank">LinkedIn</a>
+      <a href="../blog/index.html">Blog</a>
+      <a href="../roots-time/manifesto.html">Roots Time Corporation</a>
+      <a href="laugh.html">Universal Darwinism</a>
+    </nav>
+    <h1>Universal Darwinism</h1>
+    <p>This gallery will feature memes I made or remade, later available as stickers.</p>
+  </div>
+</body>
+</html>

--- a/memes/laugh_fr.html
+++ b/memes/laugh_fr.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Darwinisme universel | Memes</title>
+  <link rel="stylesheet" href="../style.css">
+  <script src="../script.js"></script>
+</head>
+<body>
+  <div class="container">
+    <div class="lang-switch">
+      <button onclick="toggleLanguage()">English version</button>
+    </div>
+    <nav class="nav-buttons">
+      <a href="../public/services.pdf" download>Télécharger le PDF</a>
+      <a href="https://github.com/raphaelreck" target="_blank">GitHub</a>
+      <a href="https://www.linkedin.com/in/raphaelreck" target="_blank">LinkedIn</a>
+      <a href="../blog/index_fr.html">Blog</a>
+      <a href="../roots-time/manifesto_fr.html">Roots Time Corporation</a>
+      <a href="laugh_fr.html">Darwinisme universel</a>
+    </nav>
+    <h1>Darwinisme universel</h1>
+    <p>Cette galerie rassemblera des mèmes que j'ai créés ou retravaillés, bientôt disponibles en autocollants.</p>
+  </div>
+</body>
+</html>

--- a/roots-time/manifesto.html
+++ b/roots-time/manifesto.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Roots Time Corporation | Manifesto</title>
+  <link rel="stylesheet" href="../style.css">
+  <script src="../script.js"></script>
+</head>
+<body>
+  <div class="container">
+    <div class="lang-switch">
+      <button onclick="toggleLanguage()">Passer en français</button>
+    </div>
+    <nav class="nav-buttons">
+      <a href="../public/services.pdf" download>Download PDF</a>
+      <a href="https://github.com/raphaelreck" target="_blank">GitHub</a>
+      <a href="https://www.linkedin.com/in/raphaelreck" target="_blank">LinkedIn</a>
+      <a href="../blog/index.html">Blog</a>
+      <a href="manifesto.html">Roots Time Corporation</a>
+      <a href="../memes/laugh.html">Universal Darwinism</a>
+    </nav>
+    <h1>Roots Time Corporation</h1>
+    <p>This page will present the manifesto and mission statement for Roots Time Corporation.</p>
+  </div>
+</body>
+</html>

--- a/roots-time/manifesto_fr.html
+++ b/roots-time/manifesto_fr.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Roots Time Corporation | Manifeste</title>
+  <link rel="stylesheet" href="../style.css">
+  <script src="../script.js"></script>
+</head>
+<body>
+  <div class="container">
+    <div class="lang-switch">
+      <button onclick="toggleLanguage()">English version</button>
+    </div>
+    <nav class="nav-buttons">
+      <a href="../public/services.pdf" download>Télécharger le PDF</a>
+      <a href="https://github.com/raphaelreck" target="_blank">GitHub</a>
+      <a href="https://www.linkedin.com/in/raphaelreck" target="_blank">LinkedIn</a>
+      <a href="../blog/index_fr.html">Blog</a>
+      <a href="manifesto_fr.html">Roots Time Corporation</a>
+      <a href="../memes/laugh_fr.html">Darwinisme universel</a>
+    </nav>
+    <h1>Roots Time Corporation</h1>
+    <p>Cette page présentera le manifeste et la mission de Roots Time Corporation.</p>
+  </div>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,8 +1,13 @@
 function toggleLanguage() {
   const current = window.location.pathname;
-  if (current.includes('index_fr.html')) {
-    window.location.href = 'index.html';
-  } else {
-    window.location.href = 'index_fr.html';
+  if (current.includes('_fr')) {
+    // replace _fr before the .html extension
+    window.location.href = current.replace('_fr', '');
+    return;
+  }
+  const dot = current.lastIndexOf('.');
+  if (dot !== -1) {
+    const path = current.substring(0, dot) + '_fr' + current.substring(dot);
+    window.location.href = path;
   }
 }

--- a/style.css
+++ b/style.css
@@ -38,17 +38,25 @@ h1, h2 {
   margin: 0;
 }
 
-.pdf-download {
+.nav-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
   margin-bottom: 30px;
 }
 
-.pdf-download a {
+.nav-buttons a {
   display: inline-block;
   background-color: #004080;
   color: #fff;
   padding: 10px 20px;
   border-radius: 6px;
   text-decoration: none;
+  transition: background-color 0.3s ease;
+}
+
+.nav-buttons a:hover {
+  background-color: #0066cc;
 }
 
 .services {
@@ -125,7 +133,7 @@ h1, h2 {
   }
   .service,
   .intro,
-  .pdf-download a,
+  .nav-buttons a,
   .call-to-action a {
     background-color: #222;
   }


### PR DESCRIPTION
## Summary
- add navbar buttons for PDF, GitHub, LinkedIn and site sections
- create bilingual placeholders for Blog, Roots Time and Universal Darwinism
- support language switching across all pages
- style navbar with dark-mode support

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6862ce65291083248530e2255190eb8b