### PR TITLE
Automate blog deploy and RSS feed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,72 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build index and feed
+        run: |
+          python <<'PY'
+import re, xml.etree.ElementTree as ET
+from datetime import datetime
+from email.utils import format_datetime
+import os
+
+index_path = 'blog/index.html'
+with open(index_path, 'r', encoding='utf-8') as f:
+    html = f.read()
+
+articles = re.findall(r'(<article class="post">.*?</article>)', html, flags=re.DOTALL)
+
+def get_date(block):
+    m = re.search(r'<time[^>]*datetime="(.*?)"', block)
+    return m.group(1) if m else ''
+
+articles.sort(key=get_date, reverse=True)
+
+new_html = re.sub(
+    r'(<div class="blog-posts">).*?(</div>)',
+    lambda m: m.group(1) + '\n' + '\n'.join(articles) + '\n' + m.group(2),
+    html,
+    flags=re.DOTALL,
+)
+
+with open(index_path, 'w', encoding='utf-8') as f:
+    f.write(new_html)
+
+rss_root = ET.Element('rss', version='2.0')
+channel = ET.SubElement(rss_root, 'channel')
+ET.SubElement(channel, 'title').text = 'Raphael Reck Blog'
+ET.SubElement(channel, 'link').text = 'https://raphaelreck.com/blog/'
+ET.SubElement(channel, 'description').text = 'Latest posts'
+
+for block in articles[:20]:
+    date_str = get_date(block)
+    dt = datetime.fromisoformat(date_str)
+    item = ET.SubElement(channel, 'item')
+    title = re.search(r'<h2>(.*?)</h2>', block, re.DOTALL).group(1).strip()
+    ET.SubElement(item, 'title').text = title
+    link = 'https://raphaelreck.com/blog/'
+    ET.SubElement(item, 'link').text = link
+    ET.SubElement(item, 'guid').text = link + '#' + date_str
+    ET.SubElement(item, 'pubDate').text = format_datetime(dt, usegmt=True)
+    text = re.sub(r'<.*?>', '', block)
+    snippet = ' '.join(text.split())
+    ET.SubElement(item, 'description').text = snippet
+
+os.makedirs('public', exist_ok=True)
+ET.ElementTree(rss_root).write('public/feed.xml', encoding='utf-8', xml_declaration=True)
+PY
+      - name: Upload via FTP
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        with:
+          server: ${{ secrets.FTP_SERVER }}
+          username: ${{ secrets.FTP_USER }}
+          password: ${{ secrets.FTP_PASS }}
+          local-dir: public
+

--- a/blog/index.html
+++ b/blog/index.html
@@ -34,10 +34,15 @@
       </blockquote>
     </section>
 
-    <div class="blog-posts">
-      <article class="blog-post">
-        <h2>Log: SVN/Git Wrangling, Laravel Rage, and CET Headaches (July 2–6)</h2>
-        <p><em>Posted on July 6, 2025</em></p>
+      <div class="blog-posts">
+        <article class="post">
+          <h2>Log: (July 16)</h2>
+          <p><em>Posted on <time datetime="2025-07-16">July 16, 2025</time></em></p>
+        </article>
+
+        <article class="post">
+          <h2>Log: SVN/Git Wrangling, Laravel Rage, and CET Headaches (July 2–6)</h2>
+          <p><em>Posted on <time datetime="2025-07-06">July 6, 2025</time></em></p>
 
         <p>This week was chaos and cleanup. Here's the damage:</p>
 
@@ -93,10 +98,6 @@
         </p>
         </article>
 
-        <article class="blog-post">
-          <h2>Log: (July 16)</h2>
-          <p><em>Posted on July 16, 2025</em></p>
-        </article>
 
       </div>
   </div>

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,29 @@
+# Deploying the Blog
+
+Follow these steps to configure FTP access and automate deployment with GitHub Actions.
+
+## 1. Create a restricted FTP user
+1. Log into your o2switch cPanel.
+2. Go to **FTP Accounts** and create a new user.
+3. Set the directory to your blog location, e.g. `/public_html/blog/`.
+4. Save the credentials for use in GitHub Secrets.
+
+## 2. Add repository secrets
+1. In GitHub, open **Settings** → **Secrets and variables** → **Actions**.
+2. Add the following secrets:
+   - `FTP_SERVER` – your FTP hostname.
+   - `FTP_USER` – the FTP username you created.
+   - `FTP_PASS` – the corresponding password.
+
+## 3. About runners
+GitHub runs workflows on virtual machines called **runners**. Using `runs-on: ubuntu-latest` gives a fresh Linux machine hosted by GitHub for every run—plenty for this static site.
+
+### Switching to self-hosted
+If you later need your own runner:
+1. Download the [GitHub runner](https://github.com/actions/runner/releases) on your server.
+2. Run `./config.sh --url https://github.com/&lt;owner&gt;/&lt;repo&gt; --token &lt;token&gt;` and follow the prompts.
+3. Start it with `./run.sh` and update the workflow to use `runs-on: [self-hosted, linux]`.
+
+## 4. Workflow trigger
+The workflow defined in `.github/workflows/publish.yml` runs on every push to the `main` branch. It sorts posts, builds `public/feed.xml`, and deploys `public/` via FTP automatically.
+


### PR DESCRIPTION
## Summary
- reorder posts in `/blog/index.html`
- add `publish.yml` workflow to sort posts, generate `public/feed.xml` and deploy over FTP
- document deployment steps in `docs/DEPLOY.md`

## Testing
- `python` linter not configured; no tests to run

------
https://chatgpt.com/codex/tasks/task_e_688a5ef577788324912cf0262f1f8450